### PR TITLE
Add jitpack to dependent maven repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,5 +17,8 @@ allprojects {
         maven {
             url 'http://repo.spring.io/milestone'
         }
+        maven {
+            url "https://jitpack.io"
+        }
     }
 }


### PR DESCRIPTION
The repository of material-dialogs was moved from jcenter to jitpack.
